### PR TITLE
update matrix.comp and run_test

### DIFF
--- a/regtests/bin/matrix.comp
+++ b/regtests/bin/matrix.comp
@@ -153,20 +153,58 @@
 
               cd $return_base ; cd $run
               rm -f diff_tempfile
-              files_1=`find -type f | sed "s#^./##"`
-              
+              files_0=`ls`
+              files_1=""
+              for file in $files_0 
+              do 
+                if [[ -d $file ]]; then
+                  if [[ $file == build* ]] || [[ $file == exe* ]] || 
+                     [[ $file == *oasis3-mct* ]] || [[ $file == toy* ]]; then 
+                    echo "do not compare build or exe directories $file" 
+                  else 
+                    #add files: 
+                    files_dir=`ls $file`
+                    for file1 in $files_dir 
+                    do 
+                      files_1="$files_1 $file1"
+                    done 
+                  fi 
+                else
+                  files_1="$files_1 $file"
+                fi
+              done 
+
               #Generate list of binary files in the directory
               binaryfiles=`grep . -r * | grep 'Binary file' | sed -e "s/^Binary file //" -e "s/ matches$//"`
 
               #Generate list of files to skip
-              skipfiles="ww3_shel.out ww3_multi.out prf.*.mww3 finished ww3_systrk.out gmon.out time_count.txt oasis_make.out oasis_clean.out toy_make.out toy_clean.out toy_model"
+              skipfiles="ww3_shel.out ww3_multi.out prf.*.mww3 finished ww3_systrk.out gmon.out time_count.txt oasis_make.out oasis_clean.out toy_model toy_make.out toy_clean.out build.log"
 
               nf_1=`echo $files_1 | wc -w | awk '{print $1}'`
               echo "  found $nf_1 files in base directory" >> $home_dir/fulldiff.tmp
 
               cd $return_comp ; cd $run
               rm -f diff_tempfile
-              files_2=`find -type f | sed "s#^./##"`
+              files_0=`ls`
+              files_2=""
+              for file in $files_0
+              do
+                if [[ -d $file ]]; then
+                  if [[ $file == build* ]] || [[ $file == exe* ]] ||
+                     [[ $file == *oasis3-mct* ]] || [[ $file == toy* ]]; then
+                    echo "do not compare build or exe directories $file" 
+                  else
+                    #add files: 
+                    files_dir=`ls $file`
+                    for file1 in $files_dir
+                    do
+                      files_2="$files_1 $file1"
+                    done
+                  fi
+                else
+                  files_2="$files_2 $file"
+                fi
+              done
 
               nf_2=`echo $files_2 | wc -w | awk '{print $1}'`
               echo "  found $nf_2 files in compare directory" >> $home_dir/fulldiff.tmp
@@ -401,19 +439,6 @@
   rm -f $home_dir/notIdenticalList.tmp
   rm -f $home_dir/summary.tmp
   rm -f $home_dir/fulldiff.tmp
-
-
-#  echo ' '
-#  cat $home_dir/fulldiff.tmp
-#  echo '**********************************************************************'
-#  
-#  echo ' '
-#  cat $home_dir/isIdenticalList.tmp
-#  echo '**********************************************************************'
-#
-#  echo ' '
-#  cat $home_dir/notIdenticalList.tmp
-#  echo '**********************************************************************'
 
   echo ' '
   echo " Saved summary to $home_dir/matrixCompSummary.txt"

--- a/regtests/bin/matrix.comp
+++ b/regtests/bin/matrix.comp
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 # --------------------------------------------------------------------------- #
 # matrix.comp Compare output of matrix for two model versions.                #
 #                                                                             #
@@ -111,13 +111,7 @@
 # 3.  Looping over work directories                                           #
 # --------------------------------------------------------------------------- #
 
-        cases=$(find . -maxdepth 1 -type d -name "work*" | grep -v work_oasis)
-        # skip to next tst if no work directory
-        echo 'run : ' $cases
-        if [ -z "$cases" ] ; then 
-          echo "skip"
-          continue
-        fi
+        cases=$(find . -maxdepth 1 -type d -name "work*" )
 
         for run in $cases
         do

--- a/regtests/bin/run_test
+++ b/regtests/bin/run_test
@@ -2090,6 +2090,7 @@ do
           then
             \rm -f $prog.inp
             \rm -f $prog.nml
+            \rm -f ounfmeta.inp
             if [ $multi -eq 2 ]
             then
               \rm -f mod_def.ww3


### PR DESCRIPTION
This is so that when we run matrix.comp we get clean comparisons, this required making sure we remove the ounfmeta.inp input in run_test (didn't test this, just deleted it from directories) and ran the comparison for ww3_tp2.14 from this branch twice so that we can easily check if there are issues in the future (instead of seeing that 204 files change as it would be easy to skip over something important that way).  

@mickaelaccensi please make sure there are not files that we should be comparing by removing all of the oasis/toy directories. 